### PR TITLE
Simplified fields on Resume Review table // have not deployed

### DIFF
--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -16,16 +16,12 @@ type ResumeReview {
     id: ID! @id
     coach: String!
     seeker: String!
-    name: String!
-    isPending: Boolean!
-    isAccepted: Boolean!
-    isDenied: Boolean!
-    isComplete: Boolean!
+    isPending: Boolean! @default(value: true)
+    isAccepted: Boolean! @default(value: false)
+    isDenied: Boolean! @default(value: false)
+    isComplete: Boolean! @default(value: false)
     createdAt: DateTime! @createdAt
     updatedAt: DateTime! @updatedAt
-    dateRequested: DateTime
     dateAccepted: DateTime
     dateCompleted: DateTime
 }
-
-

--- a/src/schema.js
+++ b/src/schema.js
@@ -48,29 +48,16 @@ type Mutation{
     ): ReviewerListing!
 
     createResumeReview(
-        name: String
-        isPending: Boolean
-        isAccepted: Boolean
-        isDenied: Boolean
-        isComplete: Boolean
-        createdAt: DateTime
-        updatedAt: DateTime
-        dateRequested: DateTime
-        dateAccepted: DateTime
-        dateCompleted: DateTime
         coach: String!
+        seeker: String!
     ): ResumeReview!
     
     updateResumeReview(
         id: String!
-        name: String
         isPending: Boolean
         isAccepted: Boolean
         isDenied: Boolean
         isComplete: Boolean
-        createdAt: DateTime
-        updatedAt: DateTime
-        dateRequested: DateTime
         dateAccepted: DateTime
         dateCompleted: DateTime
     ): ResumeReview!
@@ -97,14 +84,12 @@ type ReviewerListing {
 
 type ResumeReview {
     id: ID!
-    name: String!
     isPending: Boolean!
     isAccepted: Boolean!
     isDenied: Boolean!
     isComplete: Boolean!
     createdAt: DateTime!
     updatedAt: DateTime!
-    dateRequested: DateTime
     dateAccepted: DateTime
     dateCompleted: DateTime
     coach: User!


### PR DESCRIPTION
Updated schema and datamodel to reflect changes below.
Updated mutation for creating a resume review.

type ResumeReview { 
    id: ID! 
    ~~name: String!~~ serves no discernable purpose
    ~~~~isPending: Boolean! 
    isAccepted: Boolean! 
    isDenied: Boolean!
    isComplete: Boolean! 
    createdAt: DateTime! 
    updatedAt: DateTime! 
    ~~dateRequested: DateTime~~  same as createdAt
    ~~~~dateAccepted: DateTime 
    dateCompleted: DateTime 
    coach: User! 
    seeker: User!
    		}